### PR TITLE
Remove typings, use @types packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Restify requests validator",
   "main": "js/index.js",
   "scripts": {
-    "postinstall": "./node_modules/.bin/typings install",
     "compile": "rm -rf js/* && ./node_modules/.bin/tsc",
     "lint": "./node_modules/.bin/tslint ./ts/{,**/}*.ts ./tests/{,**/}*.ts --format verbose",
     "test": "./node_modules/.bin/mocha tests/unit --recursive --compilers ts:ts-node/register --bail",
@@ -21,6 +20,8 @@
   "license": "MIT",
   "devDependencies": {
     "@ssense/tslint-config": "^1.0.1",
+    "@types/chai": "^3.4.34",
+    "@types/mocha": "^2.2.33",
     "chai": "^3.5.0",
     "coveralls": "^2.11.14",
     "mocha": "^3.0.2",
@@ -28,8 +29,7 @@
     "pre-commit": "^1.1.3",
     "ts-node": "^1.2.2",
     "tslint": "^3.14.0",
-    "typescript": "^2.0.7",
-    "typings": "^1.3.2"
+    "typescript": "^2.0.10"
   },
   "repository": {
     "type": "git",
@@ -52,7 +52,6 @@
       "ts/*.ts"
     ],
     "exclude": [
-      "typings",
       "node_modules",
       "ts/index.ts"
     ],

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-  "globalDevDependencies": {
-    "chai": "registry:dt/chai#3.4.0+20160601211834",
-    "mocha": "registry:dt/mocha#2.2.5+20160720003353"
-  }
-}


### PR DESCRIPTION
Because I had this error when trying to install it in a project:

```
npm ERR! @ssense/restify-request-validator@1.1.5 postinstall: `typings install`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @ssense/restify-request-validator@1.1.5 postinstall script 'typings install'
```